### PR TITLE
Fix bug preventing use of xUnit v2.1

### DIFF
--- a/src/CreateUnitTest.Xunit/CreateUnitTest.Xunit.csproj
+++ b/src/CreateUnitTest.Xunit/CreateUnitTest.Xunit.csproj
@@ -71,6 +71,7 @@
     <Compile Include="XunitFrameworkProvider.cs" />
     <Compile Include="XunitFrameworkProvider_2_1.cs" />
     <Compile Include="XunitFrameworkProvider_2_0.cs" />
+    <Compile Include="XunitFrameworkProvider_2_2.cs" />
     <Compile Include="XunitSolutionManager.cs" />
     <Compile Include="XunitUnitTestClassManager.cs" />
     <Compile Include="XunitUnitTestProjectManager.cs" />

--- a/src/CreateUnitTest.Xunit/XunitFrameworkProvider_2_2.cs
+++ b/src/CreateUnitTest.Xunit/XunitFrameworkProvider_2_2.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.TestPlatform.TestGeneration.Data;
+using Microsoft.VisualStudio.TestPlatform.TestGeneration.Model;
+
+namespace CreateUnitTest.Xunit
+{
+    [Export(typeof(IFrameworkProvider))]
+    public class XunitFrameworkProvider_2_2 : XunitFrameworkProvider
+    {
+        [ImportingConstructor]
+        public XunitFrameworkProvider_2_2(IServiceProvider serviceProvider, IConfigurationSettings configurationSettings, INaming naming, IDirectory directory)
+            : base(serviceProvider, configurationSettings, naming, directory,
+                   displayName: "xUnit.net 2.2",
+                   xunitPackageVersion: "2.2.0",
+                   xunitCoreAssemblyVersionPrefix: "2.2.0.",
+                   visualStudioRunnerPackageVersion: "2.2.0")
+        { }
+    }
+}

--- a/src/IntelliTest.Xunit/IntelliTest.Xunit.csproj
+++ b/src/IntelliTest.Xunit/IntelliTest.Xunit.csproj
@@ -63,6 +63,7 @@
     <Compile Include="XunitTestFramework_2_0.cs" />
     <Compile Include="XunitTestFrameworkMetadata.cs" />
     <Compile Include="XunitTestFrameworkPackage.cs" />
+    <Compile Include="XunitTestFramework_2_2.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/IntelliTest.Xunit/XunitTestFramework_2_1.cs
+++ b/src/IntelliTest.Xunit/XunitTestFramework_2_1.cs
@@ -8,7 +8,7 @@ namespace IntelliTest.Xunit
     {
         public XunitTestFramework_2_1(IPexComponent host)
             : base(host,
-                   name: "xunit-2.0",
+                   name: "xunit-2.1",
                    prettyName: "xUnit.net 2.1",
                    xunitPackageVersion: "2.1.0",
                    visualStudioRunnerPackageVersion: "2.1.0")

--- a/src/IntelliTest.Xunit/XunitTestFramework_2_2.cs
+++ b/src/IntelliTest.Xunit/XunitTestFramework_2_2.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Pex.Engine.ComponentModel;
+
+namespace IntelliTest.Xunit
+{
+    [Serializable]
+    sealed class XunitTestFramework_2_2 : XunitTestFramework
+    {
+        public XunitTestFramework_2_2(IPexComponent host)
+            : base(host,
+                   name: "xunit-2.2",
+                   prettyName: "xUnit.net 2.2",
+                   xunitPackageVersion: "2.2.0",
+                   visualStudioRunnerPackageVersion: "2.2.0")
+        { }
+    }
+}


### PR DESCRIPTION
Numeric error in class XunitTestFramework_2_1 prevents using xUnit v2.1.0 during test creation - this option is not available via create dialog box drop down. Changing  name: "xunit-2.0" to name: "xunit-2.1" in base constructor call fixes the issue.
